### PR TITLE
Update solar data source url

### DIFF
--- a/servers/solarstorm/database/dataretriever.py
+++ b/servers/solarstorm/database/dataretriever.py
@@ -48,7 +48,7 @@ class DataRetriever:
 
     def dsd_retriever(self):
         for n in range(1996, 2013):
-            url = "http://www.swpc.noaa.gov/ftpdir/warehouse/{0}/{0}_DSD.txt"
+            url = "ftp://ftp.swpc.noaa.gov/pub/warehouse/{0}/{0}_DSD.txt"
             url = url.format(n)
 
             # Constructing output as example : destination/dsd_2011.txt


### PR DESCRIPTION
The NOAA website presently uses a different url to provide historic solar data. This PR updates the data source url to the one in use. All other functionality remain unaffected. Although this module for solar storm will be discontinued with work on the GSoC 2017 project, it is good to keep it updated for archival purposes too.