### PR TITLE
Updated install.sh to verify version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,13 @@ sleep 1
 sudo apt-get --yes update
 echo "Done Updating"
 
+version="$(python --version  2>&1 |cut -c 8)"
+if [ $version -eq 2 ] ;then
+    eval python --version
+else
+    echo "Please use Python 2.7.x"
+fi
+
 echo "--------------------------------------------------------------------"
 echo "Installing MySql"
 echo "--------------------------------------------------------------------"

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,9 @@ sleep 1
 sudo apt-get --yes update
 echo "Done Updating"
 
+echo "--------------------------------------------------------------------"
+echo "Checking Python version"
+echo "--------------------------------------------------------------------"
 version="$(python --version  2>&1 |cut -c 8)"
 if [ $version -eq 2 ] ;then
     eval python --version


### PR DESCRIPTION
A test to check that the default python is python 2.7.x . Installing the system with default python 3.x can lead to corrupt installations of ipython and pytango. This can cascade on to affect the other python based systems. 